### PR TITLE
Update KaTeX link to point to katex.org

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
                     The fastest math rendering library for the web.
                 </div>
                 <div class="actions">
-                    <a href="http://github.com/Khan/katex" class="button">
+                    <a href="https://katex.org" class="button">
                         View
                         <span class="sr-only">KaTeX</span>
                         on GitHub


### PR DESCRIPTION
katex.org is the new home of our documentation and demo page.